### PR TITLE
Dependency injection fix, removal of redundant 'def' keyword, additional condition to avoid exceptions in taglib

### DIFF
--- a/grails-app/taglib/grails/plugin/springsecurity/oauth2/OAuth2TagLib.groovy
+++ b/grails-app/taglib/grails/plugin/springsecurity/oauth2/OAuth2TagLib.groovy
@@ -23,7 +23,7 @@ class OAuth2TagLib {
     static namespace = "oauth2"
 
     SpringSecurityOauth2BaseService springSecurityOauth2BaseService
-    def SpringSecurityService springSecurityService
+    SpringSecurityService springSecurityService
 
     /**
      * Creates a link to connect to the given provider.

--- a/grails-app/taglib/grails/plugin/springsecurity/oauth2/OAuth2TagLib.groovy
+++ b/grails-app/taglib/grails/plugin/springsecurity/oauth2/OAuth2TagLib.groovy
@@ -22,7 +22,7 @@ class OAuth2TagLib {
 
     static namespace = "oauth2"
 
-    def SpringSecurityOauth2BaseService oAuth2BaseService
+    SpringSecurityOauth2BaseService springSecurityOauth2BaseService
     def SpringSecurityService springSecurityService
 
     /**
@@ -61,7 +61,7 @@ class OAuth2TagLib {
         if (!provider || !springSecurityService.isLoggedIn()) {
             return false
         }
-        def sessionKey = oAuth2BaseService.sessionKeyForAccessToken(provider)
+        def sessionKey = springSecurityOauth2BaseService.sessionKeyForAccessToken(provider)
         return (session[sessionKey] instanceof OAuth2AccessToken)
     }
 }

--- a/grails-app/taglib/grails/plugin/springsecurity/oauth2/OAuth2TagLib.groovy
+++ b/grails-app/taglib/grails/plugin/springsecurity/oauth2/OAuth2TagLib.groovy
@@ -62,6 +62,6 @@ class OAuth2TagLib {
             return false
         }
         def sessionKey = springSecurityOauth2BaseService.sessionKeyForAccessToken(provider)
-        return (session[sessionKey] instanceof OAuth2AccessToken)
+        return (session[sessionKey] && session[sessionKey] instanceof OAuth2AccessToken)
     }
 }

--- a/src/integration-test/groovy/grails/plugin/springsecurity/oauth2/OAuth2TagLibTest.groovy
+++ b/src/integration-test/groovy/grails/plugin/springsecurity/oauth2/OAuth2TagLibTest.groovy
@@ -21,12 +21,12 @@ class OAuth2TagLibTest extends Specification {
         given:
         def springSecurityService = Mock(SpringSecurityService)
         springSecurityService.isLoggedIn() >> {true}
-        def oAuth2BaseService = Mock(SpringSecurityOauth2BaseService)
-        oAuth2BaseService.sessionKeyForAccessToken(provider) >> {'OAuth2: access - t:' + provider}
-        session[oAuth2BaseService.sessionKeyForAccessToken(provider)] = new OAuth2AccessToken("${provider}_token", "${provider}_rawResponse=rawResponse")
+        def springSecurityOauth2BaseService = Mock(SpringSecurityOauth2BaseService)
+        springSecurityOauth2BaseService.sessionKeyForAccessToken(provider) >> {'OAuth2: access - t:' + provider}
+        session[springSecurityOauth2BaseService.sessionKeyForAccessToken(provider)] = new OAuth2AccessToken("${provider}_token", "${provider}_rawResponse=rawResponse")
 
         tagLib.springSecurityService = springSecurityService
-        tagLib.oAuth2BaseService = oAuth2BaseService
+        tagLib.springSecurityOauth2BaseService = springSecurityOauth2BaseService
         def template = "<oauth2:ifLoggedInWith provider=\"${provider}\">Logged in using ${provider}</oauth2:ifLoggedInWith>"
         and:
         def renderedContent = applyTemplate(template)
@@ -44,11 +44,11 @@ class OAuth2TagLibTest extends Specification {
         given:
         def springSecurityService = Mock(SpringSecurityService)
         springSecurityService.isLoggedIn() >> {true}
-        def oAuth2BaseService = Mock(SpringSecurityOauth2BaseService)
-        oAuth2BaseService.sessionKeyForAccessToken(provider) >> {'OAuth2: access - t:' + provider}
-        session[oAuth2BaseService.sessionKeyForAccessToken(provider)] = token
+        def springSecurityOauth2BaseService = Mock(SpringSecurityOauth2BaseService)
+        springSecurityOauth2BaseService.sessionKeyForAccessToken(provider) >> {'OAuth2: access - t:' + provider}
+        session[springSecurityOauth2BaseService.sessionKeyForAccessToken(provider)] = token
         tagLib.springSecurityService = springSecurityService
-        tagLib.oAuth2BaseService = oAuth2BaseService
+        tagLib.springSecurityOauth2BaseService = springSecurityOauth2BaseService
         def template = "<oauth2:ifLoggedInWith provider=\"${provider}\">Logged in using ${provider}</oauth2:ifLoggedInWith>"
         and:
         def renderedContent = applyTemplate(template)


### PR DESCRIPTION
Dependency injection fix, removal of redundant 'def' keyword, additional condition to avoid exceptions in taglib.
