### PR TITLE
Allow OpenID Connect prompt parameter in provider configurations.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencyManagement {
 dependencies {
     provided 'javax.servlet:javax.servlet-api:3.1.0'
     provided 'org.grails:grails-dependencies'
-    provided 'org.grails.plugins:spring-security-core:3.+'
+    provided 'org.grails.plugins:spring-security-core:3.1+'
 
     compile 'org.codehaus.groovy:groovy-all:2.4.3'
     compile 'com.ning:async-http-client:1.9.38'

--- a/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
@@ -141,6 +141,8 @@ class SpringSecurityOauth2BaseService {
             log.debug("Failure URL: " + failureUrl)
             def scopes = getConfigValue(providerService.providerID, "scopes") ?: null
             log.debug("Additional Scopes: " + scopes)
+            def prompt = getConfigValue(providerService.providerID, "prompt") ?: null
+            log.debug("Prompt: " + prompt)
             def apiKey = System.getenv("${providerService.getProviderID().toUpperCase()}_API_KEY") ?: getConfigValue(providerService.providerID, "api_key")
             def apiSecret = System.getenv("${providerService.getProviderID().toUpperCase()}_API_SECRET") ?: getConfigValue(providerService.providerID, "api_secret")
             log.debug("API Key: " + apiKey + ", Secret: " + apiSecret)
@@ -157,7 +159,8 @@ class SpringSecurityOauth2BaseService {
                     successUrl: successUrl,
                     failureUrl: failureUrl,
                     scope: scopes ? providerService.getScopes() + providerService.scopeSeparator + scopes : providerService.getScopes(),
-                    debug: grailsApplication.config.getProperty('oauth2.debug') ? grailsApplication.config.getProperty('oauth2.debug') : false
+                    debug: grailsApplication.config.getProperty('oauth2.debug') ? grailsApplication.config.getProperty('oauth2.debug') : false,
+                    prompt: prompt
             ))
             providerService.init(_providerConfigurationMap.get(providerService.providerID))
             providerServiceMap.put(providerService.providerID, providerService)

--- a/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
@@ -59,7 +59,10 @@ class SpringSecurityOauth2BaseService {
      */
     String getAuthorizationUrl(String providerName) {
         OAuth2AbstractProviderService providerService = getProviderService(providerName)
-        providerService.getAuthUrl(['scope': _providerConfigurationMap.get(providerName).scope])
+        Map<String, String> params = ['scope': _providerConfigurationMap.get(providerName).scope]
+        if (_providerConfigurationMap.get(providerName).prompt)
+            params.put('prompt', _providerConfigurationMap.get(providerName).prompt)
+        providerService.getAuthUrl(params)
     }
 
     /**

--- a/src/main/groovy/grails/plugin/springsecurity/oauth2/util/OAuth2ProviderConfiguration.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/oauth2/util/OAuth2ProviderConfiguration.groovy
@@ -41,4 +41,6 @@ class OAuth2ProviderConfiguration {
     String successUrl
 
     String failureUrl
+
+    String prompt
 }


### PR DESCRIPTION
Google (and possibly other OAuth providers) allows the prompt parameter from OpenID Connect. Setting this to select_account forces the account selection to be shown even when only one account is authenticated. This can be nice, so that users have a chance to add another account that may not be logged in.

This patch adds prompt as a provider configuration option, and adds it as an additional URL parameter if provided.