### PR TITLE
Publish Spring authentication events.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencyManagement {
 dependencies {
     provided 'javax.servlet:javax.servlet-api:3.1.0'
     provided 'org.grails:grails-dependencies'
-    provided 'org.grails.plugins:spring-security-core:3.+'
+    provided 'org.grails.plugins:spring-security-core:3.1+'
 
     compile 'org.codehaus.groovy:groovy-all:2.4.3'
     compile 'com.ning:async-http-client:1.9.38'

--- a/grails-app/controllers/grails/plugin/springsecurity/oauth2/SpringSecurityOAuth2Controller.groovy
+++ b/grails-app/controllers/grails/plugin/springsecurity/oauth2/SpringSecurityOAuth2Controller.groovy
@@ -25,6 +25,8 @@ import grails.plugin.springsecurity.userdetails.GrailsUser
 import org.apache.commons.lang.StringUtils
 import org.apache.commons.lang.exception.ExceptionUtils
 import org.grails.validation.routines.UrlValidator
+import org.springframework.security.authentication.AuthenticationEventPublisher
+import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.servlet.ModelAndView
 
@@ -41,6 +43,7 @@ class SpringSecurityOAuth2Controller {
 
     SpringSecurityOauth2BaseService springSecurityOauth2BaseService
     SpringSecurityService springSecurityService
+    AuthenticationEventPublisher authenticationEventPublisher
 
     /**
      * Authenticate
@@ -248,6 +251,10 @@ class SpringSecurityOAuth2Controller {
     protected void authenticateAndRedirect(@Nullable OAuth2SpringToken oAuthToken, redirectUrl) {
         session.removeAttribute SPRING_SECURITY_OAUTH_TOKEN
         SecurityContextHolder.context.authentication = oAuthToken
+        if (oAuthToken)
+            authenticationEventPublisher.publishAuthenticationSuccess(oAuthToken)
+        else
+            authenticationEventPublisher.publishAuthenticationFailure(new BadCredentialsException("OAuth authentication failed"), oAuthToken)
         redirect(redirectUrl instanceof Map ? redirectUrl : [uri: redirectUrl])
     }
 

--- a/src/integration-test/groovy/grails/plugin/springsecurity/oauth2/SpringSecurityOAuth2ControllerTest.groovy
+++ b/src/integration-test/groovy/grails/plugin/springsecurity/oauth2/SpringSecurityOAuth2ControllerTest.groovy
@@ -6,6 +6,7 @@ import grails.plugin.springsecurity.oauth2.exception.OAuth2Exception
 import grails.plugin.springsecurity.oauth2.token.OAuth2SpringToken
 import grails.plugin.springsecurity.userdetails.GrailsUser
 import grails.test.mixin.TestFor
+import org.springframework.security.authentication.AuthenticationEventPublisher
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -166,6 +167,8 @@ class SpringSecurityOAuth2ControllerTest extends Specification {
         params.provider = provider
         def springSecurityOauth2BaseService = Mock(SpringSecurityOauth2BaseService)
         controller.springSecurityOauth2BaseService = springSecurityOauth2BaseService
+        def authenticationEventPublisher = Mock(AuthenticationEventPublisher)
+        controller.authenticationEventPublisher = authenticationEventPublisher
         def sessionKey = 'OAuth2: access - t:' + provider
         springSecurityOauth2BaseService.sessionKeyForAccessToken(provider) >> { sessionKey }
         def oAuth2AccessToken = Mock(OAuth2AccessToken)


### PR DESCRIPTION
The Spring Security ProviderManager that handles normal authentication fires events, so that dependent applications can register ApplicationListeners on [valid event types](http://docs.spring.io/spring-security/site/docs/current/apidocs/org/springframework/security/authentication/event/package-summary.html).

Specifically, I registered a listener for authentication success:
```groovy
class AuthenticationSuccessListener implements ApplicationListener<AuthenticationSuccessEvent> {
    @Override
    void onApplicationEvent(AuthenticationSuccessEvent successEvent) {
        // Fetch last login date for display
    }
}
```
The spring-security-oauth2 plugin doesn't fire this event. I patched SpringSecurityOAuth2Controller.authenticateAndRedirect to fire basic success/failure events through the Spring-provided AuthenticationEventPublisher.