### PR TITLE
making OAuth2SpringToken Serializable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencyManagement {
 dependencies {
     provided 'javax.servlet:javax.servlet-api:3.1.0'
     provided 'org.grails:grails-dependencies'
-    provided 'org.grails.plugins:spring-security-core:3.+'
+    provided 'org.grails.plugins:spring-security-core:3.1+'
 
     compile 'org.codehaus.groovy:groovy-all:2.4.3'
     compile 'com.ning:async-http-client:1.9.38'

--- a/src/main/groovy/grails/plugin/springsecurity/oauth2/token/OAuth2SpringToken.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/oauth2/token/OAuth2SpringToken.groovy
@@ -77,7 +77,7 @@ abstract class OAuth2SpringToken extends AbstractAuthenticationToken {
 
     private Map extractParameters(String data, boolean json) {
         if (json) {
-          return JSON.parse(data)
+          return JSON.parse(data) as LinkedHashMap
         }
         return data?.split('&')?.collectEntries { it.split('=') as List }
     }


### PR DESCRIPTION
When using Spring Session with Spring Security, all session stored objects must be Serializable.
Grails JSONObject are not so we need a little conversion here.